### PR TITLE
Support install on YARN context

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -91,14 +91,15 @@ kerberos_zookeeper: "{{ kerberos_full }}"
 
 # Hadoop
 hadoop_base: "{{ install_path }}/hadoop-2.8.3"
-yarn_deploy: 0
-yarn_classpath: "{{ yarn_deploy }}"
 hive_port: 10000
 hive_type: binary
+yarn_deploy: 0
+yarn_classpath: "{{ yarn_deploy }}"
 yarn_resourcemanager_hostname: localhost
-yarn_memory: "{{ ram }}"
+yarn_memory: "{{ ram|float * 0.9 }}"
 yarn_tmp_dir: hdfs://localhost:8020/tmp/indexima
 yarn_name: Indexima
+is_edge: 0
 
 # HD Insight
 core_site_path: "{{ hadoop_base }}/etc/hadoop"

--- a/tasks/config_visualdoop.yaml
+++ b/tasks/config_visualdoop.yaml
@@ -6,7 +6,6 @@
     owner: "{{ service_user |d('root') }}"
     group: "{{ service_user |d('root') }}"
     mode: '0644'
-  when: is_master == 1
 
 - name: Copy log4j2_vd2.xml template to master
   template:
@@ -15,4 +14,3 @@
     owner: "{{ service_user |d('root') }}"
     group: "{{ service_user |d('root') }}"
     mode: '0644'
-  when: is_master == 1

--- a/tasks/deploy_service.yaml
+++ b/tasks/deploy_service.yaml
@@ -11,6 +11,7 @@
   when:
     - is_master == 1
     - ha == 0
+    - yarn_deploy == 0
   tags: [ 'install-galactica', 'update-galactica' ]
 
 - name: Copy Galactica Worker service file to all nodes
@@ -25,6 +26,7 @@
   when:
     - is_master == 0
     - ha == 0
+    - yarn_deploy == 0
   tags: [ 'install-galactica', 'update-galactica' ]
 
 - name: Copy Visualdoop service file to master node
@@ -37,7 +39,7 @@
     group: "root"
     mode: '0644'
   when:
-    - is_master == 1
+    - is_master == 1 or is_edge == 1
   tags: [ 'install-visualdoop', 'update-visualdoop' ]
 
 - name: Copy Galactica ha service file to all nodes
@@ -49,5 +51,7 @@
     owner: "root"
     group: "root"
     mode: '0644'
-  when: ha == 1
+  when:
+    - ha == 1
+    - yarn_deploy == 0
   tags: [ 'install-galactica', 'update-galactica' ]

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -12,20 +12,28 @@
   tags: ['install', 'prerequisites', 'install-galactica', 'install-visualdoop' ]
 
 - import_tasks: prerequisites.yaml
-  tags: [ 'install', 'prerequisites', 'centos', 'debian' ]
+  tags: [ 'install', 'prerequisites' ]
   become: yes
   become_user: root
+  when: yarn_deploy == 0
 
 ## Galactica
 
 - import_tasks: install_galactica.yaml
   tags: [ 'install', 'update', 'install-galactica', 'update-galactica']
+  when: yarn_deploy == 0
+
+- import_tasks: install_galactica.yaml
+  tags: [ 'install', 'update', 'install-galactica', 'update-galactica']
+  when:
+    - yarn_deploy == 1
+    - is_edge == 1
 
 ## Visualdoop2
 
 - import_tasks: install_visualdoop.yaml
   tags: ['install', 'update', 'install-visualdoop', 'update-visualdoop']
-  when: is_master == 1
+  when: is_master == 1 or is_edge == 1
 
 - import_tasks: deploy_service.yaml
   tags: [ 'service', install', 'update' ]
@@ -38,7 +46,7 @@
 
 - import_tasks: config_visualdoop.yaml
   tags: [ 'conf', 'conf-visualdoop' ]
-  when: is_master == 1
+  when: is_master == 1 or is_edge == 1
 
 - import_tasks: drivers.yaml
   tags: [ 'never', 'driver', 'update', 'update-galactica', 'install', 'install-galactica' ]
@@ -53,15 +61,19 @@
 
 - import_tasks: stop_indexima.yaml
   tags: [ 'never', 'restart', 'stop' ]
+  when: yarn_deploy == 0
 
 - import_tasks: start_indexima.yaml
   tags: [ 'never', 'restart', 'start' ]
+  when: yarn_deploy == 0
 
 - import_tasks: manage_service.yaml
   tags: [ 'irestart' ]
 
 - import_tasks: jdbc_url.yaml
   tags: [ 'always', 'jdbc']
+  when: yarn_deploy == 0
 
 - import_tasks: wait_for_service.yml
   tags: [ 'wait' ]
+  when: yarn_deploy == 0

--- a/tasks/manage_service.yaml
+++ b/tasks/manage_service.yaml
@@ -10,6 +10,7 @@
   when:
     - is_master == 0
     - ha == 0
+    - yarn_deploy == 0
 
 - name: Stop Galactica service on master
   become: yes
@@ -22,6 +23,7 @@
   when:
     - is_master == 1
     - ha == 0
+    - yarn_deploy == 0
 
 # HA
 - name: Stop Galactica service on ha cluster
@@ -32,7 +34,9 @@
     daemon_reload: yes
     state: stopped
   tags: [ 'never', 'grestart', 'gstop', 'istop']
-  when: ha == 1
+  when:
+    - ha == 1
+    - yarn_deploy == 0
 
 # VD 2
 - name: Stop Visualdoop service
@@ -43,7 +47,7 @@
     daemon_reload: yes
     state: stopped
   tags: [ 'never', 'vrestart', 'vstop', 'istop']
-  when: is_master == 1
+  when: is_master == 1 or is_edge == 1
 
 # Standard
 - name: Enable Galactica service on workers
@@ -57,6 +61,7 @@
   when:
     - is_master == 0
     - ha == 0
+    - yarn_deploy == 0
 
 - name: Start Galactica service on workers
   become: yes
@@ -69,6 +74,7 @@
   when:
     - is_master == 0
     - ha == 0
+    - yarn_deploy == 0
 
 - name: Enable Galactica service on master
   become: yes
@@ -81,6 +87,7 @@
   when:
     - is_master == 1
     - ha == 0
+    - yarn_deploy == 0
 
 - name: Start Galactica service on master
   become: yes
@@ -93,6 +100,7 @@
   when:
     - is_master == 1
     - ha == 0
+    - yarn_deploy == 0
 
 # HA
 - name: Enable Galactica service on ha cluster
@@ -103,7 +111,9 @@
     daemon_reload: yes
     enabled: yes
   tags: [ 'grestart', 'gstart', 'istart']
-  when: ha == 1
+  when:
+    - ha == 1
+    - yarn_deploy == 0
 
 - name: Start Galactica service on ha cluster
   become: yes
@@ -113,7 +123,9 @@
     daemon_reload: yes
     state: started
   tags: [ 'grestart', 'gstart', 'istart']
-  when: ha == 1
+  when:
+    - ha == 1
+    - yarn_deploy == 0
 
 # VD2
 - name: Enable Visualdoop service
@@ -124,7 +136,7 @@
     daemon_reload: yes
     enabled: yes
   tags: [ 'vrestart', 'vstart', 'istart']
-  when: is_master == 1
+  when: is_master == 1 or is_edge == 1
 
 - name: Start Visualdoop service
   become: yes
@@ -134,4 +146,4 @@
     daemon_reload: yes
     state: started
   tags: [ 'vrestart', 'vstart', 'istart']
-  when: is_master == 1
+  when: is_master == 1 or is_edge == 1

--- a/tasks/set_facts.yaml
+++ b/tasks/set_facts.yaml
@@ -24,6 +24,13 @@
     - indexima_bucket_name is defined
     - indexima_bucket_prefix is defined
 
+- name: Set edge if yarn deploy
+  set_fact:
+    is_edge: 0
+  when:
+    - yarn_deploy
+    - is_edge == 0
+
 - name: Split version
   set_fact:
     version_split: "{{ version.split('.') }}"

--- a/templates/galactica.conf
+++ b/templates/galactica.conf
@@ -53,7 +53,7 @@ warehouse.shared = false
 {% if yarn_deploy %}
 ## YARN parameters
 yarn.resourcemanager.hostname={{ yarn_resourcemanager_hostname }}
-yarn.memory={{ yarn_memory }}
+yarn.memory={{ yarn_memory | int}}
 yarn.dir={{ yarn_tmp_dir }}
 yarn.name = {{ yarn_name }}
 

--- a/templates/hive-site.xml
+++ b/templates/hive-site.xml
@@ -92,5 +92,10 @@
     </property>
     {% endif %}
     {% endif %}
-
+    {% if yarn_deploy %}
+    <property>
+      <name>hive.exec.scratchdir</name>
+      <value>/tmp/indexima/scratchdir</value>
+    </property>
+    {% endif %}
 </configuration>


### PR DESCRIPTION
Added two new variables yarn_deploy and is_edge to determine if the installation is on a hadoop cluster, with a YARN deployment.

When yarn_deploy is 1, installation only happens on the edge node. You still need to fill in the other hosts, and the node number for the configuration part.

Only works for dynamic mode (ha=1). 
TODO: Make it work for ha=0