### PR TITLE
Can customize vd config: cluster mode and monitor api key

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -44,6 +44,8 @@ vd2_archive: "{{ indexima_path }}/{{ vd2_file }}"
 vd2_url: "{{ indexima_base_url }}/{{ indexima_release }}/{{ indexima_sp }}/{{ vd2_file }}"
 vd2_path: "{{ indexima_path }}/visualdoop2"
 vd_path: "{{ indexima_path }}/visualdoop"
+vd_cluster_mode: 0
+vd_project_mode: 1
 
 # Config parameters
 nodes: 1
@@ -115,4 +117,3 @@ fs_AbstractFileSystem_adl_impl: "org.apache.hadoop.fs.adl.Adl"
 clean: 1
 ssl: 0
 ha: 1
-vd_cluster: 0

--- a/molecule/aws-ec2/cleanup.yml
+++ b/molecule/aws-ec2/cleanup.yml
@@ -29,7 +29,7 @@
       register: _s3_list_vd
       delegate_to: localhost
 
-    - name: Delete warehouse if created
+    - name: Delete vd2-data if created
       amazon.aws.aws_s3:
         bucket: "{{ indexima_bucket_name }}"
         object: "{{ item }}"

--- a/molecule/aws-ec2/molecule.yml
+++ b/molecule/aws-ec2/molecule.yml
@@ -35,6 +35,9 @@ provisioner:
         indexima_bucket_name: ${AWS_TEST_BUCKET_NAME}
         indexima_bucket_prefix: molecule/s3test
         galactica_conf: ${AWS_CUSTOM_CONF}
+        monitor_api_key: MyTestApiKey
+        vd_cluster_mode: 1
+        vd_project_mode: 1
     host_vars:
       localhost:
         remote_user: ${MOL_SSH_USER}

--- a/molecule/aws-ec2/verify.yml
+++ b/molecule/aws-ec2/verify.yml
@@ -47,7 +47,7 @@
         mode: list
       register: _s3_list
       delegate_to: localhost
-      failed_when: _s3_list.s3_keys | length != 1
+      failed_when: _s3_list.s3_keys | length == 0
 
     - name: Check if visualdoop-data are created
       amazon.aws.aws_s3:
@@ -94,4 +94,30 @@
       assert:
         that:
           - "'GALACTICA_MEM=1393m' in _galactica_env.stdout"
-        fail_msg: "ram is not equal 1991: {{ ansible_memtotal_mb }} in galactica-env: {{ _galactica_env.stdout }}"
+        fail_msg: "ram is not equal 1393: {{ ansible_memtotal_mb }} in galactica-env: {{ _galactica_env.stdout }}"
+
+    - name: Cat visualdoop2/config..sh
+      shell: cat /opt/indexima/visualdoop2/config.sh
+      register: _vd2_config
+      when: inventory_hostname == "instance1"
+
+    - name: Check that MONITOR_API_KEY is MyTestApiKey
+      assert:
+        that:
+          - "'MONITOR_API_KEY=MyTestApiKey' in _vd2_config.stdout"
+        fail_msg: "MONITOR_API_KEY is not MyTestApiKey"
+      when: inventory_hostname == "instance1"
+
+    - name: Check that CLUSTER_MODE is true
+      assert:
+        that:
+          - "'CLUSTER_MODE=true' in _vd2_config.stdout"
+        fail_msg: "CLUSTER_MODE is not true"
+      when: inventory_hostname == "instance1"
+
+    - name: Check that PROJECT_MODE is true
+      assert:
+        that:
+          - "'PROJECT_MODE=true' in _vd2_config.stdout"
+        fail_msg: "PROJECT_MODE is not true"
+      when: inventory_hostname == "instance1"

--- a/templates/config_vd2.sh
+++ b/templates/config_vd2.sh
@@ -68,8 +68,13 @@ export VISUALDOOP_ADMIN={{ admin_users }}
 export VISUALDOOP_DEFAULT_PASS={{ vd_pass }}
 
 {% endif %}
-{% if vd_cluster %}
+{% if vd_cluster_mode %}
 export CLUSTER_MODE=true
-export PROJECT_MODE=false
+{% endif %}
+{% if vd_project_mode %}
+export PROJECT_MODE=true
+{% endif %}
 
+{% if monitor_api_key is defined %}
+export MONITOR_API_KEY={{ monitor_api_key }}
 {% endif %}


### PR DESCRIPTION
There are now variables to choose the display mode you prefer:
- vd_cluder_mode
- vd_project_mode

They can take values 0 or 1 (bool). You can use both at the same time.

You can now specify your Monitor API Key in vd_config with the following variable
- monitor_api_key