### PR TITLE
Jdbc driver from internet

### DIFF
--- a/molecule/local/molecule.yml
+++ b/molecule/local/molecule.yml
@@ -17,5 +17,9 @@ provisioner:
       localhost:
         is_master: 1
         nodes: 1
+        redshift: 1
+        oracle: 1
+        snowflake: 1
+        postgres: 1
 verifier:
   name: ansible

--- a/molecule/local/verify.yml
+++ b/molecule/local/verify.yml
@@ -40,3 +40,13 @@
       retries: 5 # 12 * 5 seconds = 1min
       delay: 5 # Every 5 seconds
 
+    - name: List all files in galactica/driver
+      find:
+        paths: "/opt/indexima/galactica/driver"
+        patterns: "*.jar"
+      register: _jdbc_drivers
+
+    - name: Check that there are 4 drivers
+      assert:
+        that: "_jdbc_drivers.matched == 4"
+

--- a/tasks/drivers.yaml
+++ b/tasks/drivers.yaml
@@ -1,4 +1,5 @@
 ---
+## ORACLE
 - name: Copy oracle jdbc driver in /driver
   copy:
     src: ojdbc8.jar
@@ -6,8 +7,22 @@
     owner: "{{ service_user }}"
     group: "{{ service_user }}"
     mode: '0644'
-  when: oracle
+  when:
+    - oracle
+    - internet == 0
 
+- name: Download oracle jdbc driver in /driver
+  get_url:
+    url: "https://download.oracle.com/otn-pub/otn_software/jdbc/198/ojdbc8.jar"
+    dest: "{{ galactica_path }}/driver"
+    owner: "{{ service_user }}"
+    group: "{{ service_user }}"
+    mode: '0644'
+  when:
+    - oracle
+    - internet == 1
+
+## DB2
 - name: Copy db2 jdbc driver in /driver
   copy:
     src: db2jcc4.jar
@@ -17,6 +32,7 @@
     mode: '0644'
   when: db2
 
+## SNOWFLAKE
 - name: Copy snowflake jdbc driver in /driver
   copy:
     src: snowflake-jdbc-3.9.2.jar
@@ -24,8 +40,22 @@
     owner: "{{ service_user }}"
     group: "{{ service_user }}"
     mode: '0644'
-  when: snowflake
+  when:
+    - snowflake
+    - internet == 0
 
+- name: Download snowflake jdbc driver in /driver
+  get_url:
+    url: "https://repo1.maven.org/maven2/net/snowflake/snowflake-jdbc/3.9.2/snowflake-jdbc-3.9.2.jar"
+    dest: "{{ galactica_path }}/driver"
+    owner: "{{ service_user }}"
+    group: "{{ service_user }}"
+    mode: '0644'
+  when:
+    - snowflake
+    - internet == 1
+
+## HIVE
 - name: Copy hive jdbc driver in /driver
   copy:
     src: hive-jdbc-1.2.1.jar
@@ -35,6 +65,7 @@
     mode: '0644'
   when: hive
 
+## POSTGRES
 - name: Copy postgres jdbc driver in /driver
   copy:
     src: postgresql-42.2.2.jar
@@ -42,8 +73,22 @@
     owner: "{{ service_user }}"
     group: "{{ service_user }}"
     mode: '0644'
-  when: postgres
+  when:
+    - postgres
+    - internet == 0
 
+- name: Download postgres jdbc driver in /driver
+  get_url:
+    url: "https://jdbc.postgresql.org/download/postgresql-42.2.18.jar"
+    dest: "{{ galactica_path }}/driver"
+    owner: "{{ service_user }}"
+    group: "{{ service_user }}"
+    mode: '0644'
+  when:
+    - postgres
+    - internet == 1
+
+## SQLSERVER
 - name: Copy sqlserver jdbc driver in /driver
   copy:
     src: sqljdbc42.jar
@@ -53,6 +98,7 @@
     mode: '0644'
   when: sqlserver
 
+## MYSQL
 - name: Copy mysql jdbc driver in /driver
   copy:
     src: mysql-connector-java-8.0.18.jar
@@ -62,6 +108,7 @@
     mode: '0644'
   when: mysql
 
+## BIGQUERY
 - name: Copy bigquery jdbc driver in /driver
   copy:
     src: googlebigquery.jdbc42-1.2.2.1004.jar
@@ -71,6 +118,7 @@
     mode: '0644'
   when: bigquery
 
+## REDSHIFT
 - name: Copy redshift jdbc driver in /driver
   copy:
     src: redshift-jdbc42-1.2.37.1061.jar
@@ -78,8 +126,22 @@
     owner: "{{ service_user }}"
     group: "{{ service_user }}"
     mode: '0644'
-  when: redshift
+  when:
+    - redshift
+    - internet == 0
 
+- name: Download redshift jdbc driver in /driver
+  get_url:
+    url: "https://s3.amazonaws.com/redshift-downloads/drivers/jdbc/1.2.37.1061/RedshiftJDBC42-1.2.37.1061.jar"
+    dest: "{{ galactica_path }}/driver"
+    owner: "{{ service_user }}"
+    group: "{{ service_user }}"
+    mode: '0644'
+  when:
+    - redshift
+    - internet == 1
+
+## IMPALA
 - name: Copy Impala jdbc driver in /driver
   copy:
     src: jdbc-2.5.5.1007.jar

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -41,7 +41,7 @@
   when: is_master == 1
 
 - import_tasks: drivers.yaml
-  tags: [ 'never', 'driver', 'update', 'update-galactica', 'install', 'install-galactica' ]
+  tags: [ 'driver', 'update', 'update-galactica', 'install', 'install-galactica' ]
 
 - import_tasks: hadoop.yaml
   become: yes


### PR DESCRIPTION
Snowflake, Redshift, Postgres and Oracle are setable to 1 without providing your own driver. It will fetch it from the distributor (if you set internet to 1)