### PR TITLE
Cluster name param

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,42 +3,40 @@ python: "3.7"
 services:
   - docker
 env:
-  matrix:
-    - MOL_TEST: "local"
-    - MOL_TEST: "docker"
-      MOL_DISTRO: "centos7"
-    - MOL_TEST: "docker"
-      MOL_DISTRO: "ubuntu1604"
-    - MOL_TEST: "amazon"
-      MOL_AMI_NAME: "amzn2-ami-hvm-2.0*"
-      MOL_AMI_OWNER: "amazon"
-      MOL_SSH_USER: "ec2-user"
-      MOL_ENV_NAME: "amazon"
-    # - MOL_AMI_NAME: "ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-*"
-    #   MOL_AMI_OWNER: "099720109477"
-    #   MOL_SSH_USER: "ubuntu"
-    #   MOL_ENV_NAME: ubuntu18
-    # - MOL_AMI_NAME: "ubuntu/images/hvm-ssd/ubuntu-xenial-16.04-amd64-server-*"
-    #   MOL_AMI_OWNER: "099720109477"
-    #   MOL_SSH_USER: "ubuntu"
-    #   MOL_ENV_NAME: ubuntu16
-    # - MOL_AMI_NAME: 'CentOS Linux 7*'
-    #   MOL_AMI_OWNER: "aws-marketplace"
-    #   MOL_SSH_USER: "centos"
-    #   MOL_ENV_NAME: centos7
-    # - MOL_AMI_NAME: "debian-stretch-hvm-x86_64-gp2*"
-    #   MOL_AMI_OWNER: "aws-marketplace"
-    #   MOL_SSH_USER: "admin"
-    #   MOL_ENV_NAME: debian9
-
+  - MOL_TEST: "local"
+  - MOL_TEST: "docker"
+    MOL_DISTRO: "centos7"
+  - MOL_TEST: "docker"
+    MOL_DISTRO: "ubuntu1604"
+  - MOL_TEST: "amazon"
+    MOL_AMI_NAME: "amzn2-ami-hvm-2.0*"
+    MOL_AMI_OWNER: "amazon"
+    MOL_SSH_USER: "ec2-user"
+    MOL_ENV_NAME: "amazon"
+  # - MOL_AMI_NAME: "ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-*"
+  #   MOL_AMI_OWNER: "099720109477"
+  #   MOL_SSH_USER: "ubuntu"
+  #   MOL_ENV_NAME: ubuntu18
+  # - MOL_AMI_NAME: "ubuntu/images/hvm-ssd/ubuntu-xenial-16.04-amd64-server-*"
+  #   MOL_AMI_OWNER: "099720109477"
+  #   MOL_SSH_USER: "ubuntu"
+  #   MOL_ENV_NAME: ubuntu16
+  # - MOL_AMI_NAME: 'CentOS Linux 7*'
+  #   MOL_AMI_OWNER: "aws-marketplace"
+  #   MOL_SSH_USER: "centos"
+  #   MOL_ENV_NAME: centos7
+  # - MOL_AMI_NAME: "debian-stretch-hvm-x86_64-gp2*"
+  #   MOL_AMI_OWNER: "aws-marketplace"
+  #   MOL_SSH_USER: "admin"
+  #   MOL_ENV_NAME: debian9
+jobs:
+  exclude:
+    - if: branch != master
+      env: MOL_TEST=amazon
 install:
   - pip install ansible==2.10.0 molecule==3.0.8 molecule-ec2==0.2 molecule-docker==0.2.4 boto3 yamllint ansible-lint docker
 script:
   - ./travis/script_molecule.sh
-jobs:
-  exlude:
-    if: branch != master
-    env: MOL_TEST=amazon
 notifications:
   webhooks:
     urls:

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,12 @@ env:
 jobs:
   exclude:
     - if: branch != master
-      env: MOL_TEST=amazon
+      env:
+        - MOL_TEST: "amazon"
+          MOL_AMI_NAME: "amzn2-ami-hvm-2.0*"
+          MOL_AMI_OWNER: "amazon"
+          MOL_SSH_USER: "ec2-user"
+          MOL_ENV_NAME: "amazon"
 install:
   - pip install ansible==2.10.0 molecule==3.0.8 molecule-ec2==0.2 molecule-docker==0.2.4 boto3 yamllint ansible-lint docker
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,6 +35,10 @@ install:
   - pip install ansible==2.10.0 molecule==3.0.8 molecule-ec2==0.2 molecule-docker==0.2.4 boto3 yamllint ansible-lint docker
 script:
   - ./travis/script_molecule.sh
+jobs:
+  exlude:
+    if: branch != master
+    env: MOL_TEST=amazon
 notifications:
   webhooks:
     urls:

--- a/molecule/aws-ec2/verify.yml
+++ b/molecule/aws-ec2/verify.yml
@@ -86,6 +86,11 @@
           - "'this comes from s3' in _galactica_conf.stdout"
         fail_msg: "cores is not equal 1 in galactica.conf: {{ _galactica_conf.stdout }}"
 
+    - name: Check that cluster.name does not exist
+      assert:
+        that:
+          - "'cluster.name = ' not in _galactica_conf.stdout"
+
     - name: Cat galactica-env.sh
       shell: cat /opt/indexima/galactica/conf/galactica-env.sh
       register: _galactica_env

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -24,6 +24,7 @@ provisioner:
         partitions: 8
         warehouse: "/opt/indexima/warehouse"
         ha: 0
+        cluster_name: docker_test
     host_vars:
       instance:
         is_master: 1

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -56,6 +56,11 @@
           - cores == 1
           - "'cores = 1' in _galactica_conf.stdout"
 
+    - name: Check that cluster.name = docker_test
+      assert:
+        that:
+          - "'cluster.name = docker_test' in _galactica_conf.stdout"
+
     - name: Cat galactica-env.sh
       shell: cat /opt/indexima/galactica/conf/galactica-env.sh
       register: _galactica_env

--- a/templates/galactica.conf
+++ b/templates/galactica.conf
@@ -105,3 +105,6 @@ webui.ssl.keystore.password = {{ keystore_password }}
 
 {% endif %}
 {% endif %}
+{% if cluster_name is defined %}
+cluster.name = {{ cluster_name }}
+{% endif %}


### PR DESCRIPTION
Added the possibility to specify a cluster name in galactica.conf. This is useful for logging.

At the same time, optimized testing by running the aws-ec2 only on branch master.