### PR TITLE
History logs s3

### DIFF
--- a/molecule/aws-ec2/verify.yml
+++ b/molecule/aws-ec2/verify.yml
@@ -91,6 +91,26 @@
         that:
           - "'cluster.name = ' not in _galactica_conf.stdout"
 
+    - name: Check that log.dir is /var/log/indexima/logs
+      assert:
+        that:
+          - "'log.dir = /var/log/indexima/logs' in _galactica_conf.stdout"
+
+    - name: Check that hive.log.dir is /var/log/indexima/hive
+      assert:
+        that:
+          - "'hive.log.dir = /var/log/indexima/hive' in _galactica_conf.stdout"
+
+    - name: Check that history.dir is in S3
+      assert:
+        that:
+          - "'history.dir = s3a://{{ indexima_bucket_name }}/molecule/s3test/history' in _galactica_conf.stdout"
+
+    - name: Check that history.export is in S3
+      assert:
+        that:
+          - "'history.export = s3a://{{ indexima_bucket_name }}/molecule/s3test/history_csv' in _galactica_conf.stdout"
+
     - name: Cat galactica-env.sh
       shell: cat /opt/indexima/galactica/conf/galactica-env.sh
       register: _galactica_env

--- a/tasks/set_facts.yaml
+++ b/tasks/set_facts.yaml
@@ -37,6 +37,14 @@
   - indexima_bucket_name is defined
   - indexima_bucket_prefix is defined
 
+- name: Set history logs on S3 if needed
+  set_fact:
+    indexima_history_dir: "s3a://{{ indexima_bucket_name }}/{{ indexima_bucket_prefix }}/history"
+    indexima_history_export: "s3a://{{ indexima_bucket_name }}/{{ indexima_bucket_prefix }}/history_csv"
+  when:
+    - indexima_bucket_name is defined
+    - indexima_bucket_prefix is defined
+
 - name: Split version
   set_fact:
     version_split: "{{ version.split('.') }}"

--- a/templates/config_vd2.sh
+++ b/templates/config_vd2.sh
@@ -75,6 +75,6 @@ export CLUSTER_MODE=true
 export PROJECT_MODE=true
 {% endif %}
 
-{% if monitor_api_key is defined %}
+{% if monitor_api_key is defined and monitor_api_key != '' %}
 export MONITOR_API_KEY={{ monitor_api_key }}
 {% endif %}

--- a/templates/galactica.conf
+++ b/templates/galactica.conf
@@ -50,6 +50,12 @@ warehouse = {{ warehouse }}
 warehouse.shared = false
 
 {% endif %}
+## Logging
+log.dir = {{ indexima_log_dir }}
+hive.log.dir = {{ indexima_hive_log_dir }}
+history.dir = {{ indexima_history_dir }}
+history.export = {{ indexima_history_export }}
+
 {% if _custom_galactica_conf_local.skip_reason is not defined %}
 {{ _custom_galactica_conf_local.stdout }}
 {% elif _custom_galactica_conf_s3.skip_reason is not defined %}
@@ -72,12 +78,6 @@ loaders = {% if disk * 4 < cores|int %}{{ disk * 4 }}{% else %}{{ cores }}{% end
 queries = {{ cores|int * 8 }}
 hybrids = 6
 partitions = {{ partitions_number }}
-
-## Logging
-log.dir = {{ indexima_log_dir }}
-hive.log.dir = {{ indexima_hive_log_dir }}
-history.dir = {{ indexima_history_dir }}
-history.export = {{ indexima_history_export }}
 
 {% if monitor_auth %}
 ## Indexima custom authentication


### PR DESCRIPTION
Logs parameters are mandatory template. They cannot be customized with a separate galactica.conf file

If indexima_bucket_name and indexima_bucket_prefix are defined, history.dir and history.export are on the corrsponding S3 path