### PR TITLE
Add JMX options as variable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ env:
   #   MOL_ENV_NAME: debian9
 jobs:
   exclude:
-    - if: branch != master
+    - if: branch != master AND tags IS blank
       env:
         - MOL_TEST: "amazon"
           MOL_AMI_NAME: "amzn2-ami-hvm-2.0*"

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ env:
   #   MOL_ENV_NAME: debian9
 jobs:
   exclude:
-    - if: branch != master AND tags IS blank
+    - if: branch != master AND branch !~ /^v[0-9]+\.[0-9]+\.[0-9]+$/
       env:
         - MOL_TEST: "amazon"
           MOL_AMI_NAME: "amzn2-ami-hvm-2.0*"

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -30,6 +30,7 @@ provisioner:
         ha: 0
         cluster_name: docker_test
         galactica_gc_options: "-XX:+UseConcMarkSweepGC -XX:-OmitStackTraceInFastThrow -XX:NewRatio=3"
+        galactica_jmx_options: '-verbose:gc'
     host_vars:
       instance:
         is_master: 1

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -95,3 +95,9 @@
       assert:
         that:
           - '"-XX:NewRatio=3" in _galactica_env.stdout'
+
+    - name: Check that JMX_OPTIONS are present and customized
+      assert:
+        that:
+          - >
+            "export JMX_OPTIONS='-verbose:gc'" in _galactica_env.stdout

--- a/molecule/local/verify.yml
+++ b/molecule/local/verify.yml
@@ -74,4 +74,14 @@
       assert:
         that: "_jdbc_drivers.matched == 4"
 
+    - name: Cat galactica-env.sh
+      shell: cat /opt/indexima/galactica/conf/galactica-env.sh
+      register: _galactica_env
+
+    - name: Check that JMX_OPTIONS is absent
+      assert:
+        that:
+          - >
+            "export JMX_OPTIONS=" not in _galactica_env.stdout
+
 

--- a/templates/galactica-env.sh
+++ b/templates/galactica-env.sh
@@ -51,5 +51,9 @@ export AWS_SECRET_KEY={{ aws_secret_access_key }}
 export GOOGLE_APPLICATION_CREDENTIALS={{ google_credentials }}
 
 {% endif %}
+{% endif %}
+
+{% if galactica_jmx_options is defined and galactica_jmx_options != '' %}
+export JMX_OPTIONS='{{ galactica_jmx_options }}'
 
 {% endif %}

--- a/travis/script_local_test.sh
+++ b/travis/script_local_test.sh
@@ -13,7 +13,7 @@ sudo docker build --file=travis/Dockerfile.${distribution}-${version} --tag=${di
 container_id=$(mktemp)
 sudo docker run --detach --privileged -v /sys/fs/cgroup:/sys/fs/cgroup:ro --volume="${PWD}":/etc/ansible/roles/ansible-indexima-install:ro \
     ${distribution}-${version}:ansible > "${container_id}"
-  
+
 sudo docker exec "$(cat ${container_id})" env ANSIBLE_FORCE_COLOR=1 bash -c 'cd /etc/ansible/roles/ansible-indexima-install && molecule test -s local'
 
 ## Cleanup


### PR DESCRIPTION
Added a variable galactica_jmx_options which tranlate into the env var JMX_OPTIONS in galactica-env.sh

In addition, changed travis.yml to not skip the EC2 test scenario when making a new tag/release