### PR TITLE
Add monitor_api_key in galactica.conf

### DIFF
--- a/files/README.md
+++ b/files/README.md
@@ -2,4 +2,4 @@
 
 The files directory contains required libs to run Indexima with a few specific configurations.
 
-These libs are available on maven repository
+These libs are free and available on maven repository.

--- a/molecule/aws-ec2/verify.yml
+++ b/molecule/aws-ec2/verify.yml
@@ -111,6 +111,12 @@
         that:
           - "'history.export = s3a://{{ indexima_bucket_name }}/molecule/s3test/history_csv' in _galactica_conf.stdout"
 
+    - name: Check that monitor.api.key is MyTestApiKey
+      assert:
+        that:
+          - "'monitor.api.key = MyTestApiKey' in _galactica_conf.stdout"
+        fail_msg: "monitor.api.key is not MyTestApiKey"
+
     - name: Cat galactica-env.sh
       shell: cat /opt/indexima/galactica/conf/galactica-env.sh
       register: _galactica_env

--- a/templates/galactica.conf
+++ b/templates/galactica.conf
@@ -112,4 +112,9 @@ webui.ssl.keystore.password = {{ keystore_password }}
 {% endif %}
 {% if cluster_name is defined %}
 cluster.name = {{ cluster_name }}
+
+{% endif %}
+{% if monitor_api_key is defined and monitor_api_key != '' %}
+monitor.api.key = {{ monitor_api_key }}
+
 {% endif %}


### PR DESCRIPTION
When customizing monitor_api_key, it was only present in vd2_config.sh, forcing you to use a custom galactica.conf.

galactica.conf template now includes a conditional block on monitor_api_key