### PR TITLE
Fix core site path mode (0755)

### DIFF
--- a/tasks/hadoop.yaml
+++ b/tasks/hadoop.yaml
@@ -5,7 +5,7 @@
     state: directory
     owner: "{{ service_user }}"
     group: "{{ service_user }}"
-    mode: '0644'
+    mode: '0755'
 
 - name: Copy core-site.xml template
   template:


### PR DESCRIPTION
core-site.xml path directory creation had mode 0644.
Directory should always be executable.

Change to 0755