### PR TITLE
Node connect timeout customizable

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -57,6 +57,7 @@ vd_project_mode: 1
 
 # Config parameters
 nodes: 1
+node_connect_timeout: 120
 cores: "{{ ansible_processor_vcpus }}"
 ram: "{{ ansible_memtotal_mb }}"
 disk: 1

--- a/templates/galactica.conf
+++ b/templates/galactica.conf
@@ -4,7 +4,7 @@ nodes = {% for host in ansible_play_hosts %}{{ hostvars[host]['internal_host'] }
 {% elif ha == 1 %}
 nodes.requested = {{ nodes }}
 nodes.connect.min-nodes = 1
-nodes.connect.timeout = 120
+nodes.connect.timeout = {{ node_connect_timeout }}
 
 {% endif %}
 {% if warehouse_type == "nfs" %}


### PR DESCRIPTION
New variable node_connect_timeout

Set the node.connect.timeout parameter in galactica.conf in seconds. Default is 120