### PR TITLE
Service variables for master and local

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -123,3 +123,5 @@ ssl: 0
 ha: 1
 galactica_gc_options: "-XX:+UseConcMarkSweepGC -XX:-OmitStackTraceInFastThrow"
 galactica_perf_mode: stable
+service_master_ip: "{% for host in ansible_play_hosts |default(['localhost']) %}{% if hostvars[host]['is_master'] %}{{ hostvars[host]['internal_host'] }}{% endif %}{% endfor %}"
+service_local_ip: "{{ internal_host |d('LOCAL_IP') }}"

--- a/templates/indexima.service
+++ b/templates/indexima.service
@@ -8,7 +8,7 @@ Restart=always
 WorkingDirectory={{ galactica_path }}
 LimitNOFILE=65536
 User={{ indexima_service_user }}
-ExecStart=/bin/bash {{ galactica_path }}/start-node.sh --host {{ internal_host |d('LOCAL_IP') }} --attach {% for host in ansible_play_hosts |default(['localhost']) %}{% if hostvars[host]['is_master'] %}{{ hostvars[host]['internal_host'] }}{% endif %}{% endfor %}
+ExecStart=/bin/bash {{ galactica_path }}/start-node.sh --host {{ service_local_ip }} --attach {{ service_master_ip }}
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
The variables in indexima.service (dynamic mode) are now wrapped in special variables, which allows to manually override them using ansible extra vars