### PR TITLE
Support new version format

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -40,7 +40,8 @@ indexima_version: "{{ indexima_release }}{% if indexima_build is defined %}.{{ i
 # Indexima installer
 indexima_file: indexima-installer-{{ indexima_version }}.zip
 indexima_gold: "{{ indexima_release | replace('.', '') }}-{{ indexima_build | omitempty}}"
-indexima_url: "{{ indexima_base_url }}/{{ indexima_release }}/{{ indexima_sp |d('') }}/{{ indexima_file }}"
+indexima_url: "{% if indexima_release |length != 4 %}{{ indexima_base_url }}/{{ indexima_release }}/{{ indexima_sp |d('') }}{% else %}{{ indexima_base_url }}/{{ indexima_year }}/{{ indexima_month |d('') }}{% endif %}"
+galactica_url: "{{ indexima_url }}/{{ indexima_file }}"
 indexima_archive: "{{ indexima_path }}/{{ indexima_file }}"
 galactica_path: "{{ indexima_path }}/galactica"
 
@@ -49,7 +50,7 @@ admin_type: local
 vd_data: "$HOME/visualdoop-data"
 vd2_file: indexima-installer-visual2-{{ indexima_version }}.zip
 vd2_archive: "{{ indexima_path }}/{{ vd2_file }}"
-vd2_url: "{{ indexima_base_url }}/{{ indexima_release }}/{{ indexima_sp }}/{{ vd2_file }}"
+vd2_url: "{{ indexima_url }}/{{ vd2_file }}"
 vd2_path: "{{ indexima_path }}/visualdoop2"
 vd_path: "{{ indexima_path }}/visualdoop"
 vd_cluster_mode: 0

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -18,7 +18,7 @@ provisioner:
   inventory:
     group_vars:
       indexima:
-        version: 1.7.10.1132.4
+        version: 2021.1.1259
         nodes: 1
         cores: 1
         ram: 600

--- a/tasks/install_galactica.yaml
+++ b/tasks/install_galactica.yaml
@@ -28,7 +28,7 @@
 
 - name: Download Indexima zip archive
   get_url:
-    url: "{{ indexima_url }}"
+    url: "{{ galactica_url }}"
     dest: "{{ indexima_archive }}"
   when:
     - internet == 1

--- a/tasks/set_facts.yaml
+++ b/tasks/set_facts.yaml
@@ -55,15 +55,53 @@
     msg: "{{ version_split }}"
   when: version_split is defined
 
+- name: Set version format new
+  set_fact:
+    version_format_new: true
+  when: version_split[0] |length == 4
+
+- name: Set version format old
+  set_fact:
+    version_format_new: false
+  when: version_split[0] |length != 4
+
+- name: Set indexima_year
+  set_fact:
+    indexima_year: "{{ version_split[0] }}"
+    indexima_release: "{{ version_split[0] }}"
+  when:
+    - indexima_year is not defined
+    - version_format_new|bool
+
+- name: Set indexima_month
+  set_fact:
+    indexima_month: "{{ version_split[1] }}"
+    indexima_build: "{{ version_split[1] }}"
+  when:
+    - indexima_month is not defined
+    - version_format_new|bool
+
+- name: Set indexima_build
+  set_fact:
+    indexima_new_build: "{{ version_split[2] }}"
+    indexima_sp: "{{ version_split[2] }}"
+  when:
+    - indexima_new_build is not defined
+    - version_format_new|bool
+
 - name: Set indexima_release
   set_fact:
     indexima_release: "{{ version_split[0:3] |join('.') }}"
-  when: indexima_release is not defined
+  when:
+    - indexima_release is not defined
+    - not version_format_new|bool
 
 - name: Set indexima_build
   set_fact:
     indexima_build: "{{ version_split[3] }}"
-  when: indexima_build is not defined
+  when:
+    - indexima_build is not defined
+    - not version_format_new|bool
 
 - name: Set indexima_sp
   set_fact:
@@ -72,6 +110,7 @@
     - indexima_sp is not defined
     - version_split is defined
     - version_split[4] is defined
+    - not version_format_new|bool
 
 - name: Set the JDBC URL for the cluster
   set_fact:


### PR DESCRIPTION
Starting from Jan 2021, version number format has changed.

It is now YEAR.MONTH.BUILD

These changes make this new format work with the Install role, while still supporting the old format

Old format will be deprecated in June 2021