### PR TITLE
Automatically create a Main Cluster and Main Connection in VD2

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -83,13 +83,16 @@ src_google_credentials: credentials.json
 # Auth
 monitor_auth: false
 monitor_rights: false
+monitor_api_key: ChangeMe
 ldap: false
 ldap_url: null
 ldap_user_dnpattern: null
 
-galactica_users: null
-galactica_passwords: null
-galactica_admins: null
+galactica_users: admin
+galactica_passwords: admin
+galactica_admins: admin
+main_connection_user: admin
+main_connection_password: admin
 
 kerberos_full: 0
 kerberos_indexima: "{{ kerberos_full }}"

--- a/examples/hosts.local
+++ b/examples/hosts.local
@@ -109,6 +109,8 @@ vd_data=/opt/indexima/visualdoop-data
 #vd_pass=
 #admin_users=
 #vd_cluster=0
+#main_connection_user=
+#main_connection_password=
 
 ## SSL for Dev Console
 #vd_ssl=1

--- a/molecule/aws-ec2/verify.yml
+++ b/molecule/aws-ec2/verify.yml
@@ -137,7 +137,7 @@
         that:
           - '''GC_OPTIONS="-XX:+UseConcMarkSweepGC -XX:-OmitStackTraceInFastThrow"'' in _galactica_env.stdout'
 
-    - name: Cat visualdoop2/config..sh
+    - name: Cat visualdoop2/config.sh
       shell: cat /opt/indexima/visualdoop2/config.sh
       register: _vd2_config
       when: inventory_hostname == "instance1"
@@ -154,6 +154,26 @@
         that:
           - "'CLUSTER_MODE=true' in _vd2_config.stdout"
         fail_msg: "CLUSTER_MODE is not true"
+      when: inventory_hostname == "instance1"
+
+    - name: Check that Default Cluster is defined
+      assert:
+        that:
+          - "'MAIN_CLUSTER_IP=' in _vd2_config.stdout"
+          - "'MAIN_CLUSTER_NAME=' in _vd2_config.stdout"
+          - "'MAIN_CLUSTER_PORT=9999' in _vd2_config.stdout"
+          - "'MAIN_CLUSTER_API_KEY=MyTestApiKey' in _vd2_config.stdout"
+        fail_msg: "Default Cluster is not correctly defined"
+      when: inventory_hostname == "instance1"
+
+    - name: Check that Default Connection is defined
+      assert:
+        that:
+          - "'MAIN_CONNECTION_IP=' in _vd2_config.stdout"
+          - "'MAIN_CONNECTION_NAME=' in _vd2_config.stdout"
+          - "'MAIN_CONNECTION_USER=admin' in _vd2_config.stdout"
+          - "'MAIN_CONNECTION_PASSWORD=admin' in _vd2_config.stdout"
+        fail_msg: "Default Connection is not correctly defined"
       when: inventory_hostname == "instance1"
 
     - name: Check that PROJECT_MODE is true

--- a/templates/config_vd2.sh
+++ b/templates/config_vd2.sh
@@ -70,6 +70,18 @@ export VISUALDOOP_DEFAULT_PASS={{ vd_pass }}
 {% endif %}
 {% if vd_cluster_mode %}
 export CLUSTER_MODE=true
+# Default Cluster
+export MAIN_CLUSTER_IP={{ service_master_ip}}
+export MAIN_CLUSTER_NAME="Default Cluster"
+export MAIN_CLUSTER_PORT=9999
+export MAIN_CLUSTER_API_KEY={{ monitor_api_key }}
+
+# Default Connection
+export MAIN_CONNECTION_IP={{ service_master_ip}}
+export MAIN_CONNECTION_NAME="Default Connection"
+export MAIN_CONNECTION_USER={{ main_connection_user }}
+export MAIN_CONNECTION_PASSWORD={{ main_connection_password }}
+
 {% endif %}
 {% if vd_project_mode %}
 export PROJECT_MODE=true


### PR DESCRIPTION
When using cluster_mode=1

Creates a Default Cluster and Default Connection vd2_config.sh

- monitor_api_key is now set by default to the value "ChangeMe"
- galactica_users, galactica_password, and galactica_admins are now set by default to the value "admin"
- new variables main_connection_user, and main_connection_password are introduced for the default connection. Default value is "admin" for both