### PR TITLE
Adding debugging tools in prerequisites

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -9,6 +9,8 @@ java_name: "{{ install_path }}/jdk1.8.0_05"
 java_archive: "{{ install_path }}/jdk-8u5-linux-x64.tar.gz"
 java_package_centos: java-1.8.0-openjdk # Redhat family
 java_package_debian: openjdk-8-jdk # Debian family
+java_jdk_rhel: java-1.8.0-openjdk-devel #OpenJDK 8 JDK
+java_jre_debian: openjdk-8-jre-headless
 
 hadoop_version: "2.8.3"
 hadoop_file: hadoop-{{ hadoop_version }}

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -111,3 +111,9 @@
       assert:
         that:
           - _mydriver.stat.exists |bool
+
+    - name: Check that jstack is installed
+      command: "jstack -h"
+
+    - name: Check that jmap is installed
+      command: "jmap -h"

--- a/tasks/prerequisites.yaml
+++ b/tasks/prerequisites.yaml
@@ -6,6 +6,7 @@
     name:
       - unzip
       - "{{ java_package_centos }}"
+      - "{{ java_jdk_rhel }}"
   when: ansible_facts['os_family'] == "RedHat"
 
 - name: Install unzip, software-properties-common and java8 on Debian
@@ -14,6 +15,7 @@
       - unzip
       - software-properties-common
       - "{{ java_package_debian }}"
+      - "{{ java_jre_debian }}"
     update_cache: yes
   when: ansible_facts['os_family'] == "Debian"
 


### PR DESCRIPTION
Adding the following packages in prerequisites for installation :

- `java-1.8.0-openjdk-devel` (for `RHEL` (Red Hat Entreprise Linux)
- `openjdk-8-jre-headless `for `debian` systems