### PR TITLE
Default vd2 admin user fix

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -67,6 +67,9 @@ dc_archive: "{{ indexima_path }}/{{ dc_file }}"
 dc_url: "{{ indexima_url }}/{{ dc_file }}"
 dc_path: "{{ indexima_path }}/devconsole"
 
+# Default admin user in vd2
+admin_users: "admin"
+
 # Config parameters
 nodes: 1
 node_connect_timeout: 120

--- a/molecule/aws-ec2/verify.yml
+++ b/molecule/aws-ec2/verify.yml
@@ -182,3 +182,10 @@
           - "'PROJECT_MODE=true' in _vd2_config.stdout"
         fail_msg: "PROJECT_MODE is not true"
       when: inventory_hostname == "instance1"
+    
+    - name: Check that vd_config.sh has admin as admin_user
+      assert:
+        that:
+          - "'VISUALDOOP_ADMIN=' in _vd2_config.stdout"
+        fail_msg: "VISUALDOOP_ADMIN not defined"
+      when: inventory_hostname == "instance1"

--- a/molecule/aws-ec2/verify.yml
+++ b/molecule/aws-ec2/verify.yml
@@ -183,9 +183,9 @@
         fail_msg: "PROJECT_MODE is not true"
       when: inventory_hostname == "instance1"
     
-    - name: Check that vd_config.sh has admin as admin_user
+    - name: Check that vd_config.sh has the correct admin_user
       assert:
         that:
-          - "'VISUALDOOP_ADMIN=' in _vd2_config.stdout"
+          - "'VISUALDOOP_ADMIN=admin' in _vd2_config.stdout"
         fail_msg: "VISUALDOOP_ADMIN not defined"
       when: inventory_hostname == "instance1"

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -23,6 +23,7 @@ provisioner:
         cores: 1
         ram: 600
         partitions: 8
+        admin_users: "test_admin"
         warehouse: "/opt/indexima/warehouse"
         indexima_log_path: "/var/log/indexima"
         indexima_hive_log_dir: "/tmp/indexima/hive"

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -117,3 +117,13 @@
 
     - name: Check that jmap is installed
       command: "jmap -h"
+    
+    - name: Cat visualdoop2/config.sh
+      shell: cat /opt/indexima/visualdoop2/config.sh
+      register: _vd2_config
+    
+    - name: Check that vd_config.sh has admin as admin_user
+      assert:
+        that:
+          - "'VISUALDOOP_ADMIN=' in _vd2_config.stdout"
+        fail_msg: "VISUALDOOP_ADMIN not defined"

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -122,8 +122,8 @@
       shell: cat /opt/indexima/visualdoop2/config.sh
       register: _vd2_config
     
-    - name: Check that vd_config.sh has admin as admin_user
+    - name: Check that vd_config.sh has the correct admin_user
       assert:
         that:
-          - "'VISUALDOOP_ADMIN=' in _vd2_config.stdout"
+          - "'VISUALDOOP_ADMIN=test_admin' in _vd2_config.stdout"
         fail_msg: "VISUALDOOP_ADMIN not defined"

--- a/molecule/local/molecule.yml
+++ b/molecule/local/molecule.yml
@@ -19,6 +19,7 @@ provisioner:
         nodes: 1
         drivers: true
         version: 1.7.11.1183.2
+        admin_users: "admin_local"
         drivers_url: https://download.indexima.com/jdbc_drivers
         driver_list: ['db2jcc4.jar', 'googlebigquery.jdbc42-1.2.2.1004.jar', 'hive-jdbc-1.2.1.jar', 'ImpalaJDBC42-2.6.15.1017.jar',
                       'jconn4.jar', 'jdbc-2.5.5.1007.jar', 'mssql-jdbc-7.4.1.jre8-shaded.jar', 'mysql-connector-java-8.0.18.jar',

--- a/molecule/local/verify.yml
+++ b/molecule/local/verify.yml
@@ -93,10 +93,10 @@
       shell: cat /opt/indexima/visualdoop2/config.sh
       register: _vd2_config
     
-    - name: Check that vd_config.sh has admin as admin_user
+    - name: Check that vd_config.sh has the correct admin_user
       assert:
         that:
-          - "'VISUALDOOP_ADMIN=' in _vd2_config.stdout"
+          - "'VISUALDOOP_ADMIN=admin_local' in _vd2_config.stdout"
         fail_msg: "VISUALDOOP_ADMIN not defined"
 
 

--- a/molecule/local/verify.yml
+++ b/molecule/local/verify.yml
@@ -88,5 +88,15 @@
         that:
           - >
             "export JMX_OPTIONS=" not in _galactica_env.stdout
+    
+    - name: Cat visualdoop2/config.sh
+      shell: cat /opt/indexima/visualdoop2/config.sh
+      register: _vd2_config
+    
+    - name: Check that vd_config.sh has admin as admin_user
+      assert:
+        that:
+          - "'VISUALDOOP_ADMIN=' in _vd2_config.stdout"
+        fail_msg: "VISUALDOOP_ADMIN not defined"
 
 

--- a/templates/config_vd2.sh
+++ b/templates/config_vd2.sh
@@ -58,9 +58,10 @@ export VISUALDOOP_LOGIN=LDAP
 export VISUALDOOP_LDAP_URL={{ ldap_url }}
 export VISUALDOOP_LDAP_USER_DN_PATTERN={{ ldap_user_dnpattern }}
 
+{% endif %}
+
 # Setting default value to admin
 export VISUALDOOP_ADMIN=admin
-{% endif %}
 {% if admin_users is defined %}
 # VISUALDOOP Admin Users
 export VISUALDOOP_ADMIN={{ admin_users }}

--- a/templates/config_vd2.sh
+++ b/templates/config_vd2.sh
@@ -58,6 +58,8 @@ export VISUALDOOP_LOGIN=LDAP
 export VISUALDOOP_LDAP_URL={{ ldap_url }}
 export VISUALDOOP_LDAP_USER_DN_PATTERN={{ ldap_user_dnpattern }}
 
+# Setting default value to admin
+export VISUALDOOP_ADMIN=admin
 {% endif %}
 {% if admin_users is defined %}
 # VISUALDOOP Admin Users

--- a/templates/config_vd2.sh
+++ b/templates/config_vd2.sh
@@ -59,9 +59,6 @@ export VISUALDOOP_LDAP_URL={{ ldap_url }}
 export VISUALDOOP_LDAP_USER_DN_PATTERN={{ ldap_user_dnpattern }}
 
 {% endif %}
-
-# Setting default value to admin
-export VISUALDOOP_ADMIN=admin
 {% if admin_users is defined %}
 # VISUALDOOP Admin Users
 export VISUALDOOP_ADMIN={{ admin_users }}


### PR DESCRIPTION
Added new variable in defaults -> main.yaml : 
`admin_users: "admin"`

The variable can therefore be invoked in the config_vd2.sh with the default value of `admin`