### PR TITLE
Rename log4j2 template during conf

### DIFF
--- a/tasks/config_galactica.yaml
+++ b/tasks/config_galactica.yaml
@@ -59,12 +59,13 @@
     group: "{{ service_group }}"
     mode: '0644'
 
-- name: Copy log4j2.xml template to servers
-  template:
-    src: log4j2.xml
-    dest: "{{ indexima_path }}/galactica/conf/log4j2.xml"
+- name: Rename log4j2.xml.template
+  copy:
+    src: "{{ galactica_path }}/conf/log4j2.xml.template"
+    dest: "{{ galactica_path }}/conf/log4j2.xml"
     owner: "{{ service_user }}"
     group: "{{ service_group }}"
+    remote_src: yes
     mode: '0644'
 
 - name: Rename optimize_index.json.template


### PR DESCRIPTION
Log4j2 config file was a jinja template, in prevision for future parameters allowing to customizing it.

Since this is not recommended, now it will automatically rename the log4j2.xml.template file to log4j2.xml.
This means that any change to the file will be overwritten during the next conf deploy.