### PR TITLE
Docs - Variable info in the Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,32 +37,32 @@ You can also make your own playbook
 
 ## Prerequisites and install
 
- Variable                 | Default                                                                                 |
-| ----------------------- | --------------------------------------------------------------------------------------- |
-| version                 | 1.7.12.1257.1                                                                           |
-| internal_host           | "{{ hostvars[inventory_hostname]['ansible_default_ipv4']['address'] | d('LOCAL_IP') }}" |
-| internet                | 1                                                                                       |
-| internal_use            | 0
-| is_master               | 0                                                                                       |
-| systemd                 | true                                                                                    |
-| install_path            | /opt                                                                                    |
-| indexima_path           | "{{ install_path }}/indexima"                                                           |
-| indexima_logs_path      | /var/log/indexima                                                                       |
-| indexima_log_dir        | "{{ indexima_logs_path }}/logs"                                                         |
-| indexima_hive_log_dir   | "{{ indexima_logs_path }}/hive"                                                         |
-| indexima_history_dir    | "{{ indexima_logs_path }}/history"                                                      |
-| indexima_history_export | "{{ indexima_logs_path }}/history_csv"                                                  |
+ Variable                 | Description              | Possible Values  | Default                                                                                 |
+| ----------------------- | ----------------         | ---------------- | --------------------------------------------------------------------------------------- |
+| version                 | Indexima version         |                  | 1.7.12.1257.1                                                                           |
+| internal_host           | Internal IP of each host |                  | "{{ hostvars[inventory_hostname]['ansible_default_ipv4']['address'] }}"                 |
+| internet                | Hosts have internet access or not | 1/0     | 1                                                                                       |
+| internal_use            | If you store your own Indexima package, you can use this instead of the official download.indexima.com/release url | 1/0 | 0                                                                                       |
+| is_master               | A host variable that set the master. Only one host must be master | 1/0 | 0                                                                                       |
+| systemd                 | Set to true to use systemd service to start/stop Indexima | true/false | true                                                                                    |
+| install_path            | The base installation path |                  | /opt                                                                                    |
+| indexima_path           | Indexima and Visualdoop2 installation path |                  | "{{ install_path }}/indexima"                                                           |
+| indexima_logs_path      | The base path for all Indexima logs |                  | /var/log/indexima                                                                       |
+| indexima_log_dir        | Indexima logs |                  | "{{ indexima_logs_path }}/logs"                                                         |
+| indexima_hive_log_dir   | Indexima embedded Hive server logs |                  | "{{ indexima_logs_path }}/hive"                                                         |
+| indexima_history_dir    | Query history in log format |                  | "{{ indexima_logs_path }}/history"                                                      |
+| indexima_history_export | Query history in csv format |                  | "{{ indexima_logs_path }}/history_csv"                                                  |
 
 ## Config parameters
 
- Variable                 | Default                                                                                 |
-| ----------------------- | --------------------------------------------------------------------------------------- |
-| nodes                   | 1                                                                                       |
-| node_connect_timeout    | "{{ hostvars[inventory_hostname]['ansible_default_ipv4']['address'] | d('LOCAL_IP') }}" |
-| cores                   | "{{ ansible_processor_vcpus }}"                                                         |
-| ram                     | "{{ ansible_memtotal_mb }}"                                                             |
-| disk                    | 1                                                                                       |
-| warehouse_type          | local                                                                                   |
-| warehouse               | "{{ indexima_path }}/warehouse"                                                         |
-| partitions_number       | "{{ cores|int * nodes }}"                                                               |
-| cores                   | 1                                                                                       |
+ Variable                 | Description                            | Possible values               | Default        |
+| ----------------------- | -------------------------------------- | ----------------------------- | -------------- |
+| nodes                   | Number of nodes in the cluster (required) |  | 1 |
+| node_connect_timeout    | Time (in s) after which the cluster will start even if the number of nodes specified is not met |  |"{{ hostvars[inventory_hostname]['ansible_default_ipv4']['address'] | d('LOCAL_IP') }}" |
+| cores                   | Number of cores per node |  |"{{ ansible_processor_vcpus }}"                                                         |
+| ram                     | Total RAM per node. Indexima RAM will be 0.7 * ram |  |"{{ ansible_memtotal_mb }}" |
+| disk                    | Number of disk per node |  |1                                                                                       |
+| warehouse_type          | The type of filesytem used for the data warehouse | local/nfs/s3/gs/adl/hdfs | local |
+| warehouse               | Path to the warehouse. If using S3, use the full s3 path, prefixed with 's3a://' (instead of the standard s3://) |  |"{{ indexima_path }}/warehouse" |
+| partitions_number       | The number of partitions used for the data |  |"{{ cores|int * nodes }}" |
+| ha                      | Set to 1 to activate full master dynamic mode | 1/0 | 1 |

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Ansible role to install, configure and start Indexima, with a few example
 [![Build Status](https://travis-ci.com/indexima-dev/ansible-indexima-install.svg?branch=master)](https://travis-ci.com/indexima-dev/ansible-indexima-install)
 [![Ansible Galaxy](https://img.shields.io/badge/ansible--galaxy-ansible__indexima__install-blue)](https://galaxy.ansible.com/indexima_team/ansible_indexima_install)
 
-## Quickstart
+# Quickstart
 
 If you are new to Ansible, here is how to install it with pip:
 
@@ -55,7 +55,7 @@ You can also make your own playbook
 
 ## Config parameters
 
- Variable                 | Description                            | Possible values               | Default        |
+| Variable                | Description                            | Possible values               | Default        |
 | ----------------------- | -------------------------------------- | ----------------------------- | -------------- |
 | nodes                   | Number of nodes in the cluster (required) |  | 1 |
 | node_connect_timeout    | Time (in s) after which the cluster will start even if the number of nodes specified is not met |  |"{{ hostvars[inventory_hostname]['ansible_default_ipv4']['address'] | d('LOCAL_IP') }}" |
@@ -63,6 +63,38 @@ You can also make your own playbook
 | ram                     | Total RAM per node. Indexima RAM will be 0.7 * ram |  |"{{ ansible_memtotal_mb }}" |
 | disk                    | Number of disk per node |  |1                                                                                       |
 | warehouse_type          | The type of filesytem used for the data warehouse | local/nfs/s3/gs/adl/hdfs | local |
-| warehouse               | Path to the warehouse. If using S3, use the full s3 path, prefixed with 's3a://' (instead of the standard s3://) |  |"{{ indexima_path }}/warehouse" |
+| warehouse               | Path to the warehouse. If using S3, use the full s3 path, prefixed with 's3a://' (instead of the standard s3://) | | "{{ indexima_path }}/warehouse" |
 | partitions_number       | The number of partitions used for the data |  |"{{ cores|int * nodes }}" |
 | ha                      | Set to 1 to activate full master dynamic mode | 1/0 | 1 |
+
+These are the main useful variables. If you wish to customize the installation further, open an issue for more information on certain parts of the role.
+
+## Auth and integration
+
+| Variable                | Description                           | Possible values                | Default        |
+| ----------------------- | ------------------------------------- | ------------------------------ | -------------- |
+| drivers                 | Set to true if you need to upload jdbc to Indexima nodes. By default, it copies every file present in the 'files/driver' located in at the root of the Ansible folder | 1/0 | 0 |
+| drivers_url             | if you want to download the required jdbc drivers from a custom http url, set drivers_url to 1, and fill the driver_list with the names of the files. | | |
+| aws_access_key_id       | The AWS_ACCESS_KEY_ID of the account you want to use for Indexima, if you are using S3 as a warehouse type for example | | |
+| aws_secret_access_key   | The AWS_SECRET_ACCESS_KEY of the account you want to use for Indexima, if you are using S3 as a warehouse type for example | | |
+| google_credentials      | The path on every nodes to which you will copy the credentials.json for GCP access. It is recommended to use the value "{{ galactica_path }}/conf" | | |
+| fs_adl_oauth2_client_id | To use ADLS, you need to configure Azure credentials for Indexima. You can find these values on your Azure portal | | |
+| fs_adl_oauth2_tenant_id | 
+| dfs_adls_oauth2_password | 
+| fs_defaultFS            | The URL to your ADLS, it look like 'adl://BUCKET_NAME.azuredatalakestore.net' | | |
+| monitor_auth            | Set to true if you want to use the custom authentication to Indexima | true/false | false |
+| galactica_users         | If monitor_auth is set to true, you must specify a list of coma-separated usernames | | admin |
+| galactica_passwords     | Specify a list of coma-separated password. Each password match the user of the same index | | admin |
+| galactica_admins        | Specify a list of coma-separated username. The users in galactica_users that are also present here will have admin rights | |admin |
+| monitor_rights          | Set to true if you want to configure user rights for the Monitor | true/false | false |
+| monitor_api_key         | The API key that will be needed to attach a Indexima cluster to the console | | ChangeMe |
+| ldap                    | Set to true if you want to use LDAP to authenticate instead of custom auth. If set to true, ldap_url needs to be set | true/false | false |
+| ldap_url                | The complete url to your LDAP server. Eg. ldap://ldap.example.com | | |
+| ldap_user_dnpattern     | The LDAP User DN pattern to allow your users to login. Eg. cn=%s,ou=people,dc=example,dc=com. Note that the cn must always be %s for the login input variable | | |
+
+
+# External links
+
+[Indexima website](https://indexima.com)
+
+[Indexima documentation](https://docs.indexima.com)

--- a/README.md
+++ b/README.md
@@ -32,3 +32,37 @@ You can also make your own playbook
   vars:
     is_master: 1
 ```
+
+# Variables
+
+## Prerequisites and install
+
+ Variable                 | Default                                                                                 |
+| ----------------------- | --------------------------------------------------------------------------------------- |
+| version                 | 1.7.12.1257.1                                                                           |
+| internal_host           | "{{ hostvars[inventory_hostname]['ansible_default_ipv4']['address'] | d('LOCAL_IP') }}" |
+| internet                | 1                                                                                       |
+| internal_use            | 0
+| is_master               | 0                                                                                       |
+| systemd                 | true                                                                                    |
+| install_path            | /opt                                                                                    |
+| indexima_path           | "{{ install_path }}/indexima"                                                           |
+| indexima_logs_path      | /var/log/indexima                                                                       |
+| indexima_log_dir        | "{{ indexima_logs_path }}/logs"                                                         |
+| indexima_hive_log_dir   | "{{ indexima_logs_path }}/hive"                                                         |
+| indexima_history_dir    | "{{ indexima_logs_path }}/history"                                                      |
+| indexima_history_export | "{{ indexima_logs_path }}/history_csv"                                                  |
+
+## Config parameters
+
+ Variable                 | Default                                                                                 |
+| ----------------------- | --------------------------------------------------------------------------------------- |
+| nodes                   | 1                                                                                       |
+| node_connect_timeout    | "{{ hostvars[inventory_hostname]['ansible_default_ipv4']['address'] | d('LOCAL_IP') }}" |
+| cores                   | "{{ ansible_processor_vcpus }}"                                                         |
+| ram                     | "{{ ansible_memtotal_mb }}"                                                             |
+| disk                    | 1                                                                                       |
+| warehouse_type          | local                                                                                   |
+| warehouse               | "{{ indexima_path }}/warehouse"                                                         |
+| partitions_number       | "{{ cores|int * nodes }}"                                                               |
+| cores                   | 1                                                                                       |

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -94,8 +94,7 @@ drivers: 0
 aws: 0
 gs: 0
 azure: 0
-src_google_credentials: credentials.json
-google_credentials: "{{ galactica_path }}/conf"
+#google_credentials: "{{ galactica_path }}/conf"
 
 # Auth
 monitor_auth: false
@@ -146,6 +145,7 @@ fs_AbstractFileSystem_adl_impl: "org.apache.hadoop.fs.adl.Adl"
 clean: 1
 ssl: 0
 ha: 1
+dynamic: 1
 galactica_gc_options: "-XX:+UseConcMarkSweepGC -XX:-OmitStackTraceInFastThrow"
 galactica_perf_mode: stable
 service_master_ip: "{% for host in ansible_play_hosts |default(['localhost']) %}{% if hostvars[host]['is_master'] %}{{ hostvars[host]['internal_host'] }}{% endif %}{% endfor %}"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -21,7 +21,7 @@ hadoop_path: "{{ install_path }}/{{ hadoop_file }}"
 
 #standalone
 #don't change
-version: 1.7.10.1132.4
+version: 1.7.12.1257.1
 internal_host: "{{ hostvars[inventory_hostname]['ansible_default_ipv4']['address'] | d('LOCAL_IP') }}"
 internet: 1
 internal_use: 0
@@ -95,6 +95,7 @@ aws: 0
 gs: 0
 azure: 0
 src_google_credentials: credentials.json
+google_credentials: "{{ galactica_path }}/conf"
 
 # Auth
 monitor_auth: false

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -90,11 +90,10 @@ drivers: 0
 #drivers_url: 0
 #driver_list: []
 
-# Cloud Storage
-aws: 0
-gs: 0
-azure: 0
+# Cloud Credentials
 #google_credentials: "{{ galactica_path }}/conf"
+#aws_access_key_id: 
+#aws_secret_access_key:
 
 # Auth
 monitor_auth: false

--- a/examples/hosts.local
+++ b/examples/hosts.local
@@ -148,8 +148,8 @@ vd_data=/opt/indexima/visualdoop-data
 #kerberos_keytab_path=
 
 ## Indexima Hive config
-## If you need custom authentication for Indexima Hive, uncomment custom_auth (If you want to use LDAP, keep commented and see below).
-#custom_auth=1
+## If you need custom authentication for Indexima Hive, uncomment monitor_auth (If you want to use LDAP, keep commented and see below).
+#monitor_auth=1
 galactica_users="admin,hadoop"
 galactica_passwords="admin,password"
 galactica_admins="admin"

--- a/examples/hosts.multi-node
+++ b/examples/hosts.multi-node
@@ -1,0 +1,25 @@
+# ansible_host is the host to which you connect via ssh.
+# internal_host is the host as seen by all the Indexima cluster nodes.
+# both are required
+[indexima]
+node1 ansible_host=10.0.0.1 is_master=1
+node2 ansible_host=10.0.0.2
+node3 ansible_host=10.0.0.3
+
+[indexima:vars]
+
+ansible_user={{ lookup('env', 'USER') }}
+ansible_ssh_private_key_file=
+ansible_ssh_extra_args='-o StrictHostKeyChecking=no'
+
+internet=1
+nodes=3
+version=2021.1.1334.2
+install_path=/opt
+warehouse_type=nfs
+warehouse=/mnt/warehouse
+vd_data=/opt/indexima/visualdoop-data
+monitor_auth=1
+galactica_users="admin,hadoop"
+galactica_passwords="admin,password"
+galactica_admins="admin"

--- a/examples/hosts.s3
+++ b/examples/hosts.s3
@@ -1,0 +1,29 @@
+# ansible_host is the host to which you connect via ssh.
+# internal_host is the host as seen by all the Indexima cluster nodes.
+# both are required
+[indexima]
+node1 ansible_host=10.0.0.1 is_master=1
+node2 ansible_host=10.0.0.2
+node3 ansible_host=10.0.0.3
+
+[indexima:vars]
+
+ansible_user={{ lookup('env', 'USER') }}
+ansible_ssh_private_key_file=
+ansible_ssh_extra_args='-o StrictHostKeyChecking=no'
+
+internet=1
+nodes=3
+version=2021.1.1334.2
+install_path=/opt
+warehouse_type=s3
+vd_data=/opt/indexima/visualdoop-data
+monitor_auth=1
+galactica_users="admin,hadoop"
+galactica_passwords="admin,password"
+galactica_admins="admin"
+
+## Set these variables
+warehouse=s3a://mybucket/warehouse
+aws_access_key_id=AKIAIOSFODNN7EXAMPLE
+aws_secret_access_key=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY

--- a/molecule/aws-ec2/molecule.yml
+++ b/molecule/aws-ec2/molecule.yml
@@ -29,7 +29,7 @@ provisioner:
     group_vars:
       ec2:
         hadoop_url: "https://download.indexima.com/libs/hadoop-2.8.3.tar.gz"
-        version: 1.7.10.1132.4
+        version: 2021.1.1334.2
         service_user: ${MOL_SSH_USER}
         nodes: 2
         warehouse_type: s3

--- a/molecule/aws-ec2/molecule.yml
+++ b/molecule/aws-ec2/molecule.yml
@@ -29,7 +29,7 @@ provisioner:
     group_vars:
       ec2:
         hadoop_url: "https://download.indexima.com/libs/hadoop-2.8.3.tar.gz"
-        version: 2021.1.1334.2
+        version: 1.7.10.1132.4
         service_user: ${MOL_SSH_USER}
         nodes: 2
         warehouse_type: s3

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -19,7 +19,7 @@ provisioner:
     group_vars:
       indexima:
         hadoop_url: "https://download.indexima.com/libs/hadoop-2.8.3.tar.gz"
-        version: 1.7.12.1257.1
+        version: 2021.1.1334.2
         nodes: 1
         cores: 1
         ram: 600

--- a/tasks/config_galactica.yaml
+++ b/tasks/config_galactica.yaml
@@ -111,4 +111,3 @@
     group: "{{ service_group }}"
     mode: '0644'
   when: google_credentials is defined
-  tags: test-google

--- a/templates/galactica-env.sh
+++ b/templates/galactica-env.sh
@@ -43,8 +43,6 @@ export AWS_SECRET_KEY={{ aws_secret_access_key }}
 
 {% endif %}
 
-{% endif %}
-
 {% if google_credentials is defined %}
 # Google Credentials for using GS
 export GOOGLE_APPLICATION_CREDENTIALS={{ google_credentials }}

--- a/templates/galactica-env.sh
+++ b/templates/galactica-env.sh
@@ -36,21 +36,19 @@ export NODESERVER_JVM_OPTIONS="-Djava.security.auth.login.config={{ galactica_pa
 # JVM parameters
 export GC_OPTIONS="{{ galactica_gc_options }}"
 
-{% if warehouse_type == "s3" or warehouse_type == "s3like" or aws == 1 %}
-# AWS credentials for loading from S3
 {% if aws_access_key_id is defined and aws_secret_access_key is defined %}
+# AWS credentials for loading from S3
 export AWS_ACCESS_KEY_ID={{ aws_access_key_id }}
 export AWS_SECRET_KEY={{ aws_secret_access_key }}
 
 {% endif %}
 
 {% endif %}
-{% if warehouse_type == "gs" or gs == 1 %}
-# Google Credentials for using GS
+
 {% if google_credentials is defined %}
+# Google Credentials for using GS
 export GOOGLE_APPLICATION_CREDENTIALS={{ google_credentials }}
 
-{% endif %}
 {% endif %}
 
 {% if galactica_jmx_options is defined and galactica_jmx_options != '' %}

--- a/templates/galactica.conf
+++ b/templates/galactica.conf
@@ -99,7 +99,7 @@ session.users={{ galactica_users }}
 session.passwords={{ galactica_passwords }}
 users.in.admin.role={{ galactica_admins }}
 
-{% elif ldap == 1 %}
+{% elif ldap| bool %}
 webui.authenticate = true
 users.in.admin.role={{ galactica_admins }}
 {% else %}

--- a/templates/hive-site.xml
+++ b/templates/hive-site.xml
@@ -28,7 +28,7 @@
         <value>false</value>
     </property>
 
-    {% if ldap %}
+    {% if ldap |bool %}
     <property>
        <name>hive.server2.authentication</name>
        <value>LDAP</value>


### PR DESCRIPTION
In addition to providing a more helpful Readme, a number of variable and templates have been fixed and refactored.

- ldap is now a boolean
- aws, gs, azure is now removed. Only the aws or gcp credentials variable is required
- src_google_credentials has been removed. The file now must be named credentials.json and be placed in the files folder. Only the google_credentials (dest path) is required to use gcp credentials
- gcp credentials tmp tag has been removed
- custom_auth has been renamed monitor_auth in the hosts.local