### PR TITLE
Set is_master to 0 in group vars

### DIFF
--- a/examples/hosts.local
+++ b/examples/hosts.local
@@ -205,6 +205,7 @@ galactica_admins="admin"
 #ha=0
 #zookeeper_quorum=
 #zookeeper_namespace=
+is_master=0
 
 ## HD Insight
 #core_site_path="/etc/hadoop/core-site.xml"

--- a/examples/hosts.multi-node
+++ b/examples/hosts.multi-node
@@ -12,6 +12,7 @@ ansible_user={{ lookup('env', 'USER') }}
 ansible_ssh_private_key_file=
 ansible_ssh_extra_args='-o StrictHostKeyChecking=no'
 
+is_master=0
 internet=1
 nodes=3
 version=2021.1.1334.2

--- a/examples/hosts.s3
+++ b/examples/hosts.s3
@@ -12,6 +12,7 @@ ansible_user={{ lookup('env', 'USER') }}
 ansible_ssh_private_key_file=
 ansible_ssh_extra_args='-o StrictHostKeyChecking=no'
 
+is_master=0
 internet=1
 nodes=3
 version=2021.1.1334.2

--- a/molecule/aws-ec2/molecule.yml
+++ b/molecule/aws-ec2/molecule.yml
@@ -41,6 +41,7 @@ provisioner:
         vd_cluster_mode: 1
         vd_project_mode: 1
         ha: 1
+        is_master: 0
     host_vars:
       localhost:
         remote_user: ${MOL_SSH_USER}
@@ -50,7 +51,5 @@ provisioner:
         galactica_conf: ${AWS_CUSTOM_CONF}
       instance1:
         is_master: 1
-      instance2:
-        is_master: 0
 verifier:
   name: ansible


### PR DESCRIPTION
Individual host vars have precedence on group vars.

So by settings is_master to 0 in the group vars, we prevent the _not defined_ error while not changing anything to already configured master hosts.

This has been done in the hosts example files, and must be done manually in already existing hosts files