### PR TITLE
Support galactica extended file content

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ You can also make your own playbook
 | ha                      | Set to 1 to activate full master dynamic mode | 1/0 | 1 |
 | node_port               | Port used by the nodes to communicate with each other. This will use the port specified here, and the port +1 | | 19999 |
 | monitor_port            | Port used to access the monitor api | | 9999 |
+| galactica_conf_extended | Path (on the Ansible host) to a file containing galactica.conf parameters. The content of the file will be appended at the ended of the automatically generated galactica.conf. Use this if a parameter you need is not yet supported by the Ansible install role. *Warning*: Be careful not to write a parameter already present in the template | | |
 
 These are the main useful variables. If you wish to customize the installation further, open an issue for more information on certain parts of the role.
 

--- a/molecule/default/cleanup.yml
+++ b/molecule/default/cleanup.yml
@@ -1,0 +1,11 @@
+---
+- name: Cleanup
+  hosts: localhost
+  connection: local
+  gather_facts: false
+  no_log: "{{ molecule_no_log }}"
+  tasks:
+    - name: Cleanup galactica_extended
+      file:
+        path: /tmp/galactica_extended
+        state: absent

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -45,6 +45,7 @@ provisioner:
         vd_cluster_mode: 1
         vd_cluster_only: 1
         vd_project_mode: 0
+        galactica_conf_extended: /tmp/galactica_extended
         analyzer:
           mode: INCREMENTAL
           smart_metrics_days: 15

--- a/molecule/default/prepare.yml
+++ b/molecule/default/prepare.yml
@@ -17,3 +17,9 @@
       ansible.builtin.group:
         name: "{{ service_group }}"
         state: present
+    
+    - name: Write extended galactica conf
+      local_action:
+        module: copy
+        content: 'myvar = 1'
+        dest: /tmp/galactica_extended

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -177,6 +177,12 @@
           - "'monitor.api.key = ChangeMe' in _galactica_conf.stdout"
         fail_msg: "monitor.api.key is not ChangeMe"
 
+    - name: Check that galactica extended content is present
+      assert:
+        that:
+          - "'myvar = 1' in _galactica_conf.stdout"
+        fail_msg: "galactica extended content is not present"
+
     # galactica-env.sh
     - name: Cat galactica-env.sh
       shell: cat /opt/indexima/galactica/conf/galactica-env.sh

--- a/tasks/config_galactica.yaml
+++ b/tasks/config_galactica.yaml
@@ -8,6 +8,36 @@
     - '"s3://" not in galactica_conf'
   changed_when: false
 
+- name: Copy galactica.conf extended content from local file
+  local_action:
+    module: shell
+    _raw_params: "cat {{ galactica_conf_extended }}"
+  register: _galactica_conf_extended_local
+  when:
+    - galactica_conf_extended is defined
+    - galactica_conf_extended != ''
+    - '"s3://" not in galactica_conf_extended'
+  changed_when: false
+
+- name: Set bucket and path to galactica_conf_extended when s3
+  set_fact:
+    galactica_conf_extended_bucket: "{{ galactica_conf_extended.split('/')[2] }}"
+    galactica_conf_extended_path: "{{ galactica_conf_extended.split('/')[3:] |join('/') }}"
+  when:
+    - galactica_conf_extended is defined
+    - '"s3://" in galactica_conf_extended'
+
+- name: Get galactica extended content from s3 file
+  aws_s3:
+    bucket: "{{ galactica_conf_extended_bucket }}"
+    object: "{{ galactica_conf_extended_path }}"
+    mode: getstr
+  register: _galactica_conf_extended_s3
+  when:
+    - galactica_conf_extended is defined
+    - '"s3://" in galactica_conf_extended'
+  changed_when: false
+
 - name: Set bucket and path to galactica_conf when s3
   set_fact:
     galactica_conf_bucket: "{{ galactica_conf.split('/')[2] }}"

--- a/templates/galactica.conf
+++ b/templates/galactica.conf
@@ -135,3 +135,11 @@ analyser.smart.optimizer = {{ analyzer.smart_optimizer | quote }}
 
 node.port = {{ node_port }}
 webui.port = {{ monitor_port }}
+
+{% if _galactica_conf_extended_local.skip_reason is not defined %}
+{{ _galactica_conf_extended_local.stdout }}
+{% endif %}
+
+{% if _galactica_conf_extended_s3.skip_reason is not defined %}
+{{ _galactica_conf_extended_s3.content }}
+{% endif %}


### PR DESCRIPTION
Added a new variable galactica_conf_extended.

It is a path to a local (Ansible host) file. The content of this file will be appended at the end of the galactica.conf template, after formatting